### PR TITLE
update version and version management for package development versions

### DIFF
--- a/oq-python3.5-3.5.4/debian/changelog
+++ b/oq-python3.5-3.5.4/debian/changelog
@@ -1,4 +1,13 @@
+oq-python3.5 (3.5.4-6~gem04~xenial01) xenial; urgency=medium
+
+  [Matteo Nastasi]
+  * removed obsolete 'Breaks' directive from control.in file
+  * fix versioning management for development package versions
+
+ -- Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>  Wed, 11 Jul 2018 06:44:55 +0000
+
 oq-python3.5 (3.5.4-5~gem03~xenial01) xenial; urgency=medium
+
   [Matteo Nastasi]
   * missing .buildinfo file copy to host added
 

--- a/packager-guest.sh
+++ b/packager-guest.sh
@@ -80,6 +80,7 @@ pkg_maj="$(echo "$pkg_vers" | sed -n 's/^\([0-9]\+\).*/\1/gp')"
 pkg_min="$(echo "$pkg_vers" | sed -n 's/^[0-9]\+\.\([0-9]\+\).*/\1/gp')"
 pkg_bfx="$(echo "$pkg_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.\([0-9]\+\).*/\1/gp')"
 pkg_deb="$(echo "$pkg_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.[0-9]\+\(-[^+]\+\).*/\1/gp')"
+pkg_debsfx="$(echo "$pkg_vers" | sed -n "s/^[0-9]\+\.[0-9]\+\.[0-9]\+\(-[^+]\+\).*/\1/g;s/^-[0-9]*//g;s/~${BUILD_UBUVER_REFERENCE}[0-9]*//gp")"
 pkg_suf="$(echo "$pkg_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.[0-9]\+-[^+]\+\(+.*\)/\1/gp')"
 
 if [ $BUILD_DEVEL -eq 1 ]; then
@@ -102,7 +103,7 @@ if [ $BUILD_DEVEL -eq 1 ]; then
     fi
 
     (
-      echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~${BUILD_UBUVER}01~dev${dt}+${hash}) ${BUILD_UBUVER}; urgency=low"
+      echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}${pkg_debsfx}~${BUILD_UBUVER}01~dev${dt}+${hash}) ${BUILD_UBUVER}; urgency=low"
       echo
       echo "  [Automatic Script]"
       echo "  * Development version from $hash commit"

--- a/packager.sh
+++ b/packager.sh
@@ -272,6 +272,7 @@ _build_innervm_run () {
 
     ssh -t "$lxc_ip" "
         set -e
+        export GEM_DEB_PACKAGE=\"$GEM_DEB_PACKAGE\"
         export BUILD_UBUVER=\"$BUILD_UBUVER\"
         export dt=\"$dt\"
         export DEBEMAIL=\"$DEBEMAIL\"


### PR DESCRIPTION
This PR fix 2 bugs:
1. currently development package versions are in the format:
`oq-python3.5 - 3.5.4-5~xenial01~dev1531226821+1a9d39a`
When the last `changelog` entry was:
`oq-python3.5 (3.5.4-5~gem03~xenial01) xenial; urgency=medium`
missing the `~gem03` suffix
2. the `-<number>` suffix was not correctly increased when there are new entries above the last release header in the `changelog` file